### PR TITLE
fix includes for MacOSX build

### DIFF
--- a/Modules/util.c
+++ b/Modules/util.c
@@ -25,7 +25,7 @@
 #include <stdlib.h>
 #include <signal.h>
 
-#ifdef unix
+#if defined(unix) || defined( __APPLE__)
 #include <sys/types.h>
 #include <sys/stat.h>
 #else

--- a/Modules/util.h
+++ b/Modules/util.h
@@ -29,7 +29,12 @@
 #ifndef _UTIL_
 #define _UTIL_
 
-#include <malloc.h>
+#ifdef __APPLE__
+	#include <stdlib.h>
+#else
+	#include <malloc.h>
+#endif
+
 #include <stdio.h>
 #include <string.h>
 


### PR DESCRIPTION
Mac OS X doesn't come with <malloc.h>.  And it uses a Unix path delimiter `/`. 